### PR TITLE
Allow passing in a URL to Redis

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,11 @@ var api = {
     if (cache) {
       config.cache = cache.timeout || 86400;
       var redis = require("redis");
-      client = redis.createClient(cache.port, cache.host, cache.options);
+      if (cache.url) {
+        client = redis.createClient(cache.url, cache.options);
+      } else {
+        client = redis.createClient(cache.port, cache.host, cache.options);
+      }
       if (cache.auth) {
         client.auth(cache.auth);
       }


### PR DESCRIPTION
This is a simple modification to allow passing a URL into the Redis client, in addition to continuing to allow the individual parameters.